### PR TITLE
Local runtime mock agent

### DIFF
--- a/bin/mock-agent.mjs
+++ b/bin/mock-agent.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * mock-agent
+ *
+ * A deterministic, stdio-driven mock agent that speaks length-prefixed JSON.
+ *
+ * Frame format: [uint32be byteLength][utf8 JSON bytes]
+ */
+
+import process from "node:process";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: false });
+
+function encodeFrame(message) {
+  const json = JSON.stringify(message);
+  const body = textEncoder.encode(json);
+
+  const header = new Uint8Array(4);
+  const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  view.setUint32(0, body.byteLength, false);
+
+  const frame = new Uint8Array(4 + body.byteLength);
+  frame.set(header, 0);
+  frame.set(body, 4);
+  return frame;
+}
+
+class FrameDecoder {
+  buffer = new Uint8Array(0);
+  offset = 0;
+
+  push(chunk) {
+    if (!chunk || chunk.byteLength === 0) return [];
+
+    if (this.offset > 0) {
+      this.buffer = this.buffer.slice(this.offset);
+      this.offset = 0;
+    }
+
+    const next = new Uint8Array(this.buffer.byteLength + chunk.byteLength);
+    next.set(this.buffer, 0);
+    next.set(chunk, this.buffer.byteLength);
+    this.buffer = next;
+
+    const out = [];
+    while (true) {
+      const remaining = this.buffer.byteLength - this.offset;
+      if (remaining < 4) break;
+
+      const view = new DataView(
+        this.buffer.buffer,
+        this.buffer.byteOffset + this.offset,
+        4
+      );
+      const length = view.getUint32(0, false);
+      if (remaining < 4 + length) break;
+
+      const start = this.offset + 4;
+      const end = start + length;
+      const payload = this.buffer.slice(start, end);
+      this.offset = end;
+
+      const json = textDecoder.decode(payload);
+      out.push(JSON.parse(json));
+    }
+
+    if (this.offset === this.buffer.byteLength) {
+      this.buffer = new Uint8Array(0);
+      this.offset = 0;
+    }
+
+    return out;
+  }
+}
+
+function parseArgs(argv) {
+  const out = {
+    chunks: 5,
+    emitToolCalls: false
+  };
+
+  for (const arg of argv.slice(2)) {
+    if (arg === "--emitToolCalls") out.emitToolCalls = true;
+    if (arg.startsWith("--chunks=")) {
+      const n = Number(arg.slice("--chunks=".length));
+      if (Number.isFinite(n) && n >= 1) out.chunks = Math.floor(n);
+    }
+  }
+  return out;
+}
+
+function chunkString(text, parts) {
+  if (parts <= 1) return [text];
+  const size = Math.ceil(text.length / parts);
+  const chunks = [];
+  for (let i = 0; i < parts; i++) {
+    const start = i * size;
+    const end = Math.min(text.length, (i + 1) * size);
+    if (start >= text.length) break;
+    chunks.push(text.slice(start, end));
+  }
+  return chunks.length > 0 ? chunks : [""];
+}
+
+async function writeMessage(msg) {
+  const frame = encodeFrame(msg);
+  const ok = process.stdout.write(frame);
+  if (!ok) {
+    await new Promise((resolve, reject) => {
+      const onDrain = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (err) => {
+        cleanup();
+        reject(err);
+      };
+      const cleanup = () => {
+        process.stdout.off("drain", onDrain);
+        process.stdout.off("error", onError);
+      };
+      process.stdout.on("drain", onDrain);
+      process.stdout.on("error", onError);
+    });
+  }
+}
+
+const config = parseArgs(process.argv);
+const decoder = new FrameDecoder();
+
+const sessions = new Map(); // sessionId -> { history: Array<{role, content}>, turns: number }
+let sessionCounter = 0;
+
+function getOrCreateSession(sessionId) {
+  const existing = sessions.get(sessionId);
+  if (existing) return existing;
+  const created = { history: [], turns: 0 };
+  sessions.set(sessionId, created);
+  return created;
+}
+
+await writeMessage({ type: "ready", pid: process.pid, version: 1 });
+
+async function handleChunk(chunk) {
+  const messages = decoder.push(
+    new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+  );
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || typeof msg.type !== "string") continue;
+
+    if (msg.type === "session/start") {
+      const requested = typeof msg.sessionId === "string" ? msg.sessionId : undefined;
+      const sessionId = requested ?? `session-${++sessionCounter}`;
+      getOrCreateSession(sessionId);
+      await writeMessage({ type: "session/started", sessionId });
+      continue;
+    }
+
+    if (msg.type === "session/send") {
+      const sessionId =
+        typeof msg.sessionId === "string" ? msg.sessionId : `session-${++sessionCounter}`;
+      const content = typeof msg.content === "string" ? msg.content : "";
+      const session = getOrCreateSession(sessionId);
+
+      session.history.push({ role: "user", content });
+      session.turns += 1;
+
+      const assistantContent = `MockAgent response #${session.turns}: ${content}`;
+      const deltas = chunkString(assistantContent, config.chunks);
+
+      if (config.emitToolCalls) {
+        await writeMessage({
+          type: "tool/call",
+          sessionId,
+          name: "mock.tool",
+          args: { turn: session.turns, inputLength: content.length }
+        });
+      }
+
+      for (let i = 0; i < deltas.length; i++) {
+        await writeMessage({
+          type: "session/stream",
+          sessionId,
+          index: i,
+          delta: deltas[i]
+        });
+        // Deterministic async boundary without timers.
+        await Promise.resolve();
+      }
+
+      const assistantMessage = { role: "assistant", content: assistantContent };
+      session.history.push(assistantMessage);
+      await writeMessage({
+        type: "session/complete",
+        sessionId,
+        message: assistantMessage,
+        history: session.history.slice()
+      });
+    }
+  }
+}
+
+let processing = Promise.resolve();
+process.stdin.on("data", (chunk) => {
+  processing = processing.then(() => handleChunk(chunk)).catch(() => {});
+});
+
+process.stdin.on("end", () => {
+  process.exit(0);
+});
+

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
       "require": "./dist/index.cjs"
     }
   },
+  "bin": {
+    "mock-agent": "./bin/mock-agent.mjs"
+  },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "scripts": {
     "build": "tsup",

--- a/src/framing.ts
+++ b/src/framing.ts
@@ -1,0 +1,89 @@
+import { TextDecoder, TextEncoder } from "node:util";
+
+/**
+ * Length-prefixed JSON framing.
+ *
+ * Frame format: [uint32be byteLength][utf8 JSON bytes]
+ */
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: false });
+
+export class FramingError extends Error {
+  override name = "FramingError";
+}
+
+export function encodeFrame(message: unknown): Uint8Array {
+  const json = JSON.stringify(message);
+  const body = textEncoder.encode(json);
+
+  const header = new Uint8Array(4);
+  const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  view.setUint32(0, body.byteLength, false);
+
+  const frame = new Uint8Array(4 + body.byteLength);
+  frame.set(header, 0);
+  frame.set(body, 4);
+  return frame;
+}
+
+export class FrameDecoder {
+  private buffer: Uint8Array = new Uint8Array(0);
+  private offset = 0;
+
+  push(chunk: Uint8Array): unknown[] {
+    if (chunk.byteLength === 0) return [];
+
+    // Compact existing buffer before appending new data.
+    if (this.offset > 0) {
+      this.buffer = this.buffer.slice(this.offset);
+      this.offset = 0;
+    }
+
+    const next = new Uint8Array(this.buffer.byteLength + chunk.byteLength);
+    next.set(this.buffer, 0);
+    next.set(chunk, this.buffer.byteLength);
+    this.buffer = next;
+
+    const out: unknown[] = [];
+    while (true) {
+      const remaining = this.buffer.byteLength - this.offset;
+      if (remaining < 4) break;
+
+      const view = new DataView(
+        this.buffer.buffer,
+        this.buffer.byteOffset + this.offset,
+        4
+      );
+      const length = view.getUint32(0, false);
+      if (length > 100 * 1024 * 1024) {
+        throw new FramingError(`Frame too large: ${length} bytes`);
+      }
+
+      if (remaining < 4 + length) break;
+
+      const start = this.offset + 4;
+      const end = start + length;
+      const payload = this.buffer.slice(start, end);
+      this.offset = end;
+
+      const json = textDecoder.decode(payload);
+      try {
+        out.push(JSON.parse(json) as unknown);
+      } catch (err) {
+        throw new FramingError(
+          `Invalid JSON payload (${length} bytes): ${(err as Error).message}`
+        );
+      }
+    }
+
+    // If we've consumed everything, reset to avoid unbounded growth.
+    if (this.offset === this.buffer.byteLength) {
+      this.buffer = new Uint8Array(0);
+      this.offset = 0;
+    }
+
+    return out;
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,8 @@ export function helloWorld(name?: string): string {
   return `Hello, ${who}!`;
 }
 
+export * from "./local-runtime.js";
+export * from "./protocol.js";
+export * from "./framing.js";
+export * from "./stdio-transport.js";
+

--- a/src/local-runtime.ts
+++ b/src/local-runtime.ts
@@ -1,0 +1,40 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+import { StdioJsonTransport } from "./stdio-transport.js";
+
+export interface SpawnLocalAgentOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface LocalAgentConnection {
+  child: ChildProcessWithoutNullStreams;
+  transport: StdioJsonTransport;
+  close: () => Promise<void>;
+}
+
+export function spawnLocalAgent(
+  options: SpawnLocalAgentOptions
+): LocalAgentConnection {
+  const child = spawn(options.command, options.args, {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: options.cwd,
+    env: options.env
+  });
+
+  const transport = new StdioJsonTransport(child.stdout, child.stdin);
+
+  const close = async () => {
+    transport.close();
+    if (!child.killed) child.kill();
+    await new Promise<void>((resolve) => {
+      if (child.exitCode !== null) return resolve();
+      child.once("exit", () => resolve());
+    });
+  };
+
+  return { child, transport, close };
+}
+

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,62 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export type ChatRole = "user" | "assistant";
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ReadyMessage {
+  type: "ready";
+  pid: number;
+  version: 1;
+}
+
+export interface SessionStartMessage {
+  type: "session/start";
+  sessionId?: string;
+}
+
+export interface SessionStartedMessage {
+  type: "session/started";
+  sessionId: string;
+}
+
+export interface SessionSendMessage {
+  type: "session/send";
+  sessionId: string;
+  content: string;
+}
+
+export interface SessionStreamMessage {
+  type: "session/stream";
+  sessionId: string;
+  index: number;
+  delta: string;
+}
+
+export interface ToolCallPlaceholderMessage {
+  type: "tool/call";
+  sessionId: string;
+  name: string;
+  args: JsonObject;
+}
+
+export interface SessionCompleteMessage {
+  type: "session/complete";
+  sessionId: string;
+  message: ChatMessage;
+  history: ChatMessage[];
+}
+
+export type ClientToAgentMessage = SessionStartMessage | SessionSendMessage;
+
+export type AgentToClientMessage =
+  | ReadyMessage
+  | SessionStartedMessage
+  | SessionStreamMessage
+  | ToolCallPlaceholderMessage
+  | SessionCompleteMessage;
+

--- a/src/stdio-transport.ts
+++ b/src/stdio-transport.ts
@@ -1,0 +1,113 @@
+import type { Readable, Writable } from "node:stream";
+
+import { encodeFrame, FrameDecoder } from "./framing.js";
+
+type Resolver<T> = (value: T | PromiseLike<T>) => void;
+
+export class StdioJsonTransport {
+  private readonly decoder = new FrameDecoder();
+  private readonly queue: unknown[] = [];
+  private readonly waiters: Array<Resolver<IteratorResult<unknown>>> = [];
+  private ended = false;
+  private readonly onDataBound: (chunk: Buffer) => void;
+  private readonly onEndBound: () => void;
+  private readonly onErrorBound: (err: Error) => void;
+
+  constructor(
+    private readonly readable: Readable,
+    private readonly writable: Writable
+  ) {
+    this.onDataBound = (chunk) => this.onData(chunk);
+    this.onEndBound = () => this.onEnd();
+    this.onErrorBound = (err) => this.onError(err);
+
+    this.readable.on("data", this.onDataBound);
+    this.readable.on("end", this.onEndBound);
+    this.readable.on("error", this.onErrorBound);
+  }
+
+  async send(message: unknown): Promise<void> {
+    if (this.ended) throw new Error("Transport is closed");
+
+    const frame = encodeFrame(message);
+    const ok = this.writable.write(frame);
+    if (!ok) {
+      await new Promise<void>((resolve, reject) => {
+        const onDrain = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: Error) => {
+          cleanup();
+          reject(err);
+        };
+        const cleanup = () => {
+          this.writable.off("drain", onDrain);
+          this.writable.off("error", onError);
+        };
+        this.writable.on("drain", onDrain);
+        this.writable.on("error", onError);
+      });
+    }
+  }
+
+  close(): void {
+    if (this.ended) return;
+    this.ended = true;
+
+    this.readable.off("data", this.onDataBound);
+    this.readable.off("end", this.onEndBound);
+    this.readable.off("error", this.onErrorBound);
+
+    while (this.waiters.length > 0) {
+      const resolve = this.waiters.shift();
+      resolve?.({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<unknown> {
+    return {
+      next: () => this.next()
+    };
+  }
+
+  private next(): Promise<IteratorResult<unknown>> {
+    if (this.queue.length > 0) {
+      const value = this.queue.shift();
+      return Promise.resolve({ done: false, value });
+    }
+    if (this.ended) return Promise.resolve({ done: true, value: undefined });
+
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private onData(chunk: Buffer): void {
+    try {
+      const messages = this.decoder.push(chunk);
+      for (const msg of messages) this.enqueue(msg);
+    } catch (err) {
+      this.onError(err as Error);
+    }
+  }
+
+  private onEnd(): void {
+    this.close();
+  }
+
+  private onError(_err: Error): void {
+    // For now: fail closed and let consumers stop cleanly.
+    this.close();
+  }
+
+  private enqueue(message: unknown): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value: message });
+      return;
+    }
+    this.queue.push(message);
+  }
+}
+

--- a/tests/framing.test.ts
+++ b/tests/framing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeFrame, FrameDecoder } from "../src/framing.js";
+
+describe("length-prefixed JSON framing", () => {
+  it("decodes a single frame", () => {
+    const decoder = new FrameDecoder();
+    const msg = { hello: "world", n: 1 };
+    const frame = encodeFrame(msg);
+    const out = decoder.push(frame);
+    expect(out).toEqual([msg]);
+  });
+
+  it("decodes frames split across chunks", () => {
+    const decoder = new FrameDecoder();
+    const msg = { type: "split", ok: true };
+    const frame = encodeFrame(msg);
+
+    const partA = frame.slice(0, 2);
+    const partB = frame.slice(2, 7);
+    const partC = frame.slice(7);
+
+    expect(decoder.push(partA)).toEqual([]);
+    expect(decoder.push(partB)).toEqual([]);
+    expect(decoder.push(partC)).toEqual([msg]);
+  });
+
+  it("decodes multiple frames from a single chunk", () => {
+    const decoder = new FrameDecoder();
+    const a = { a: 1 };
+    const b = { b: 2 };
+    const combined = new Uint8Array(encodeFrame(a).byteLength + encodeFrame(b).byteLength);
+    combined.set(encodeFrame(a), 0);
+    combined.set(encodeFrame(b), encodeFrame(a).byteLength);
+
+    expect(decoder.push(combined)).toEqual([a, b]);
+  });
+});
+

--- a/tests/local-runtime-mock-agent.test.ts
+++ b/tests/local-runtime-mock-agent.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+
+import type {
+  AgentToClientMessage,
+  SessionCompleteMessage,
+  SessionStreamMessage,
+  ToolCallPlaceholderMessage
+} from "../src/protocol.js";
+import { spawnLocalAgent } from "../src/local-runtime.js";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      const t = setTimeout(() => reject(new Error(`Timeout: ${label}`)), ms);
+      // Avoid keeping the event loop alive on Node versions that support it.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      (t as unknown as { unref?: () => void }).unref?.();
+    })
+  ]);
+}
+
+async function nextMessage(
+  iter: AsyncIterator<unknown>,
+  label: string
+): Promise<AgentToClientMessage> {
+  const res = await withTimeout(iter.next(), 2000, label);
+  if (res.done) throw new Error(`Unexpected end of stream while waiting for ${label}`);
+  return res.value as AgentToClientMessage;
+}
+
+async function waitForType<T extends AgentToClientMessage["type"]>(
+  iter: AsyncIterator<unknown>,
+  type: T
+): Promise<Extract<AgentToClientMessage, { type: T }>> {
+  while (true) {
+    const msg = await nextMessage(iter, `message type ${type}`);
+    if (msg.type === type) return msg as Extract<AgentToClientMessage, { type: T }>;
+  }
+}
+
+describe("local runtime + mock-agent integration", () => {
+  it("streams deterministically and preserves session history", async () => {
+    const mockAgentPath = fileURLToPath(new URL("../bin/mock-agent.mjs", import.meta.url));
+    const conn = spawnLocalAgent({
+      command: process.execPath,
+      args: [mockAgentPath, "--chunks=4"]
+    });
+
+    try {
+      const iter = conn.transport[Symbol.asyncIterator]();
+
+      const ready = await waitForType(iter, "ready");
+      expect(ready.version).toBe(1);
+
+      await conn.transport.send({ type: "session/start", sessionId: "s1" });
+      const started = await waitForType(iter, "session/started");
+      expect(started.sessionId).toBe("s1");
+
+      await conn.transport.send({ type: "session/send", sessionId: "s1", content: "hello" });
+
+      const deltas: SessionStreamMessage[] = [];
+      let complete: SessionCompleteMessage | undefined;
+      while (!complete) {
+        const msg = await nextMessage(iter, "stream/complete for turn #1");
+        if (msg.type === "session/stream") deltas.push(msg);
+        if (msg.type === "session/complete") complete = msg;
+      }
+
+      const combined = deltas
+        .sort((a, b) => a.index - b.index)
+        .map((d) => d.delta)
+        .join("");
+      expect(combined).toBe("MockAgent response #1: hello");
+      expect(complete.history).toEqual([
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "MockAgent response #1: hello" }
+      ]);
+
+      await conn.transport.send({ type: "session/send", sessionId: "s1", content: "world" });
+      const deltas2: SessionStreamMessage[] = [];
+      let complete2: SessionCompleteMessage | undefined;
+      while (!complete2) {
+        const msg = await nextMessage(iter, "stream/complete for turn #2");
+        if (msg.type === "session/stream") deltas2.push(msg);
+        if (msg.type === "session/complete") complete2 = msg;
+      }
+
+      const combined2 = deltas2
+        .sort((a, b) => a.index - b.index)
+        .map((d) => d.delta)
+        .join("");
+      expect(combined2).toBe("MockAgent response #2: world");
+      expect(complete2.history).toHaveLength(4);
+      expect(complete2.history[0]?.content).toBe("hello");
+      expect(complete2.history[2]?.content).toBe("world");
+    } finally {
+      await conn.close();
+    }
+  });
+
+  it("can emit tool-call placeholder events", async () => {
+    const mockAgentPath = fileURLToPath(new URL("../bin/mock-agent.mjs", import.meta.url));
+    const conn = spawnLocalAgent({
+      command: process.execPath,
+      args: [mockAgentPath, "--chunks=2", "--emitToolCalls"]
+    });
+
+    try {
+      const iter = conn.transport[Symbol.asyncIterator]();
+      await waitForType(iter, "ready");
+
+      await conn.transport.send({ type: "session/start", sessionId: "s-tool" });
+      await waitForType(iter, "session/started");
+
+      await conn.transport.send({
+        type: "session/send",
+        sessionId: "s-tool",
+        content: "hi"
+      });
+
+      let sawToolCall = false;
+      let sawComplete = false;
+
+      while (!sawComplete) {
+        const msg = await nextMessage(iter, "tool call and completion");
+        if (msg.type === "tool/call") {
+          const tool = msg as ToolCallPlaceholderMessage;
+          sawToolCall = true;
+          expect(tool.name).toBe("mock.tool");
+          expect(tool.sessionId).toBe("s-tool");
+        }
+        if (msg.type === "session/complete") sawComplete = true;
+      }
+
+      expect(sawToolCall).toBe(true);
+    } finally {
+      await conn.close();
+    }
+  });
+});
+


### PR DESCRIPTION
Implement local runtime (stdio transport + framing) and a `mock-agent` CLI for deterministic streaming and session history.

---
<a href="https://cursor.com/background-agent?bcId=bc-56ff11a9-4fcc-4d45-9dcb-a010a74d9d26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56ff11a9-4fcc-4d45-9dcb-a010a74d9d26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

