### PR TITLE
Refactor chat record type

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -23,42 +23,259 @@ export interface ChatMessage {
 /** RFC3339/ISO-8601 timestamp string (e.g. `new Date().toISOString()`). */
 export type Timestamp = string;
 
-export type ChatStatus = "created" | "running" | "completed" | "failed" | "cancelled" | "unknown";
-
-export type ExecutionLocation = "local" | "remote" | "unknown";
-export type Durability = "ephemeral" | "durable" | "unknown";
-
 /**
- * Execution hints for UX and safety.
- * Not part of A2A core, but compatible as an extension.
+ * TChat is a vendor-agnostic description of a chat-like communication space.
+ *
+ * Notes:
+ * - This is a *flat* record type (no tier concepts).
+ * - Many fields may be unknown for some providers; adapters can fill what they can.
+ * - Use `extra` for experimental/provider-specific additions.
+ * - Use `_rawRest` / `_rawAll` as escape hatches for raw payloads.
  */
-export interface ChatExecution {
-  location: ExecutionLocation;
-  durability: Durability;
-  providerId?: string; // e.g. "cursor" | "openhands" | "local"
-  hint?: string; // optional human-readable warning/help text
-  _rawData?: unknown; // passthrough provider fields
-}
+export type TChat = {
+  // -----------------------------
+  // Identity / Linking
+  // -----------------------------
 
-export interface ChatRef {
+  /** Internal unique id within Agnet (SSOT). */
   id: string;
-  providerId: string;
-  status: ChatStatus;
 
-  title?: string; // "chat name" or derived summary (optional)
-  createdAt?: Timestamp;
-  updatedAt?: Timestamp;
+  /**
+   * External identifier or composite key within the native system.
+   * Examples:
+   * - "123456"
+   * - { owner: "org", repo: "app", number: 42 }  // GitHub issue/PR
+   * - { workspaceId: "...", threadId: "..." }    // SaaS chat systems
+   */
+  externalId?: string | Record<string, unknown>;
 
-  // Optional metadata commonly shown in UIs:
-  repo?: { url?: string; ref?: string };
-  pr?: { url?: string; number?: number };
+  /**
+   * Canonical link/URI to open this chat in the native UI when available.
+   * Examples: https://..., slack://..., file://...
+   */
+  source?: string;
 
-  execution: ChatExecution;
+  /** Human-friendly name/title of the chat. */
+  title?: string;
 
-  _rawData?: unknown; // provider payload passthrough
-}
+  /** Human-friendly description/topic/purpose if available. */
+  description?: string;
 
-// ChatRef is the main Tier1 interaction container (chat-first).
+  // -----------------------------
+  // Lifecycle / Storage
+  // -----------------------------
+
+  /**
+   * Where the chat is hosted.
+   * - local: exists in the current environment (process/runtime) and may disappear when it stops
+   * - remote: backed by an external service
+   */
+  location: "local" | "remote";
+
+  /**
+   * Persistence model (normalized).
+   * - ephemeral: intended to disappear (in-memory / one-off)
+   * - session: tied to a runtime/session lifecycle
+   * - durable: stored externally (cloud service, filesystem, database)
+   */
+  persistence: "ephemeral" | "session" | "durable";
+
+  /**
+   * Time-to-live in milliseconds if the chat is temporary / self-destructing.
+   * Not all providers expose this value.
+   */
+  ttlMs?: number;
+
+  // -----------------------------
+  // Access / Participation (for the *current* agent/provider identity)
+  // -----------------------------
+
+  /**
+   * Whether the current identity can read messages from this chat.
+   * This is an *effective permission hint*, not a full auth model.
+   */
+  canRead: boolean;
+
+  /**
+   * Whether the current identity can post messages into this chat.
+   * This is an *effective permission hint*, not a full auth model.
+   */
+  canPost: boolean;
+
+  /**
+   * Whether joining/participation requires an approval flow (invite/request).
+   * For many providers this may be unknown.
+   */
+  requiresApprovalToJoin?: boolean;
+
+  /**
+   * Whether an explicit agreement/terms acceptance is required to read/post.
+   * For many providers this may be unknown.
+   */
+  agreementRequired?: boolean;
+
+  /**
+   * Visibility scope (may be unknown).
+   * - public: broadly accessible/discoverable
+   * - unlisted: accessible by link, not broadly discoverable
+   * - org/team: restricted to an organization/team boundary
+   * - private: restricted to explicit members
+   */
+  visibility?: "public" | "unlisted" | "org" | "team" | "private";
+
+  // -----------------------------
+  // Classification (vendor-agnostic)
+  // -----------------------------
+
+  /**
+   * How messages are structured in this chat.
+   *
+   * - chat: real-time (or near real-time) conversational chat room style
+   * - comments: ordered comments attached to an entity (task/PR/review/post/etc).
+   *             Replies/threads are represented at the *message level* (e.g., parentId),
+   *             not by a separate channel type.
+   * - dm: direct messages between participants
+   * - email: mailbox-style threaded communication
+   * - call: audio/video call session (may have chat or not)
+   * - feed: broadcast-style posts with optional comments (social feed)
+   * - forum: forum-style discussions with categories/topics
+   * - other: anything else
+   */
+  channelType: "chat" | "comments" | "dm" | "email" | "call" | "feed" | "forum" | "other";
+
+  /**
+   * What this chat is "about" (its primary context).
+   *
+   * - task: work item / issue-tracker item / to-do (GitHub issue, Linear issue, local task)
+   * - pr: pull request / merge request discussion
+   * - epic: higher-level tracker item grouping tasks
+   * - runtime: tool/runtime session (Cursor/OpenHands/IDE agent session)
+   * - support: customer support / helpdesk conversation
+   * - messenger: general-purpose messaging app (WhatsApp/Telegram/Slack/etc)
+   * - doc_review: review thread for documents/specs/contracts
+   * - incident: incident/ops war-room style discussion
+   * - social: social/community discussion (Reddit/YouTube comments/etc)
+   * - other: none of the above / unknown
+   *
+   * Note: If omitted, treat as unknown.
+   */
+  contextType?:
+    | "task"
+    | "pr"
+    | "epic"
+    | "runtime"
+    | "support"
+    | "messenger"
+    | "doc_review"
+    | "incident"
+    | "social"
+    | "other";
+
+  /**
+   * Pointer to the primary context entity that the chat is attached to.
+   *
+   * Avoid "*Ref" naming to not collide with "React refs" mental model.
+   *
+   * Examples:
+   * - "https://github.com/org/repo/issues/123"
+   * - { kind: "github.issue", owner: "org", repo: "repo", number: 123 }
+   * - "file:///.../local-task.json"
+   */
+  contextLink?: string | Record<string, unknown>;
+
+  // -----------------------------
+  // People / Moderation (may be partial or huge)
+  // -----------------------------
+
+  /**
+   * Known subscribers/watchers if available.
+   * WARNING: can be huge or unknown; adapters may return partial data.
+   */
+  subscribers?: Array<{ id?: string; name?: string; externalId?: unknown }>;
+
+  /**
+   * Roles of the current identity inside this chat (member/moderator/bot/etc), if known.
+   */
+  roles?: string[];
+
+  /** Known moderators/admins if available (often partial). */
+  moderators?: Array<{ id?: string; name?: string; externalId?: unknown }>;
+
+  /**
+   * Reporting mechanisms available in this environment (if known).
+   * Examples: abuse/fraud/bug.
+   */
+  reportKinds?: Array<"abuse" | "fraud" | "bug" | "other">;
+
+  // -----------------------------
+  // Limits / Policies (often provider-specific)
+  // -----------------------------
+
+  /**
+   * Platform constraints and policies (if known).
+   * Some of these may later be modeled as "capabilities".
+   */
+  limits?: {
+    /** Max messages per time window (if known). */
+    rateLimit?: { max?: number; perMs?: number };
+
+    /** Max text length per message (if known). */
+    maxTextChars?: number;
+
+    /** Max attachment size in bytes (if known). */
+    maxAttachmentBytes?: number;
+
+    /** Allowed attachment types (if known). */
+    allowedAttachmentKinds?: string[];
+  };
+
+  /** Free-form tags/labels (e.g., issue labels). */
+  tags?: string[];
+
+  /** Pinned messages or pinned references, if supported/available. */
+  pinned?: Array<string | Record<string, unknown>>;
+
+  /** Image/logo/icon reference (url or provider-specific structure). */
+  image?: { url?: string; alt?: string } | string;
+
+  /** External website for the chat/product/community if relevant. */
+  website?: string;
+
+  /**
+   * API reference for the underlying system (docs/schema), if relevant.
+   * Example: { type: "openapi", url: "...", meta: {...} }
+   */
+  apiReference?: { type: string; url?: string; meta?: Record<string, unknown> };
+
+  // -----------------------------
+  // Attachments (loose, optional)
+  // -----------------------------
+
+  /**
+   * Links to attachments posted by the current identity or detected in the chat.
+   * Many providers expose attachments as separate resources; keep it loose.
+   */
+  attachments?: Array<{ url?: string; kind?: string; meta?: Record<string, unknown> }>;
+
+  // -----------------------------
+  // Extension points
+  // -----------------------------
+
+  /**
+   * Experimental/provider-specific fields that don't fit the normalized model yet.
+   * Intentionally `any` to allow fast iteration.
+   */
+  extra?: any;
+
+  /** Extra raw fields not mapped into the normalized shape. */
+  _rawRest?: Record<string, unknown>;
+
+  /**
+   * Full raw payload as returned by the underlying adapter.
+   * Potentially huge; avoid enabling by default in production.
+   */
+  _rawAll?: unknown;
+};
 
 export type MessageRole = "user" | "assistant" | "system" | "tool";
 
@@ -128,8 +345,8 @@ export type ChatEvent =
     })
   | (ChatEventBase & { type: "message.completed"; message: Message })
   | (ChatEventBase & { type: "artifact.created"; artifact: Artifact })
-  | (ChatEventBase & { type: "chat.completed"; chat: ChatRef })
-  | (ChatEventBase & { type: "chat.cancelled"; chat: ChatRef })
+  | (ChatEventBase & { type: "chat.completed"; chat: TChat })
+  | (ChatEventBase & { type: "chat.cancelled"; chat: TChat })
   | (ChatEventBase & { type: "chat.failed"; error: string });
 
 /**
@@ -202,20 +419,19 @@ export interface ChatsCreateMessage {
 
 export interface ChatsCreatedMessage {
   type: "chats/created";
-  chat: ChatRef;
+  chat: TChat;
 }
 
 export interface ChatsListMessage {
   type: "chats/list";
   providerId?: string;
-  status?: ChatStatus;
   cursor?: string;
   limit?: string;
 }
 
 export interface ChatsListResultMessage {
   type: "chats/listResult";
-  chats: ChatRef[];
+  chats: TChat[];
   nextCursor?: string;
 }
 
@@ -226,7 +442,7 @@ export interface ChatsGetMessage {
 
 export interface ChatsGetResultMessage {
   type: "chats/getResult";
-  chat: ChatRef;
+  chat: TChat;
 }
 
 export interface ChatsCancelMessage {

--- a/tests/a2a-core-entities.test.ts
+++ b/tests/a2a-core-entities.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
-import type { AgentEvent, Artifact, ChatEvent, ChatRef, Message, Part } from "../src/protocol.js";
+import type { AgentEvent, Artifact, ChatEvent, Message, Part, TChat } from "../src/protocol.js";
 
-describe("A2A core entities (Tier1)", () => {
+describe("Core entities", () => {
   it("can model Chat -> Message -> Part and Artifact", () => {
     const now = new Date().toISOString();
 
     const chat = {
       id: "c1",
-      providerId: "provider-1",
-      status: "created",
-      createdAt: now,
-      execution: { location: "local", durability: "ephemeral" }
-    } satisfies ChatRef;
+      title: "Chat 1",
+      location: "local",
+      persistence: "ephemeral",
+      canRead: true,
+      canPost: true,
+      channelType: "chat",
+      _rawRest: { createdAt: now }
+    } satisfies TChat;
 
     const parts = [{ kind: "text", text: "hello" }] satisfies Part[];
 
@@ -31,7 +34,7 @@ describe("A2A core entities (Tier1)", () => {
       parts: [{ kind: "text", text: "result" }]
     } satisfies Artifact;
 
-    expect(chat.status).toBe("created");
+    expect(chat.location).toBe("local");
     expect(msg.chatId).toBe("c1");
     expect(msg.parts[0]).toEqual({ kind: "text", text: "hello" });
     expect(artifact.type).toBe("text/plain");


### PR DESCRIPTION
Replace `ChatRef` with the new vendor-agnostic `TChat` type and update all related protocol messages, mock agent, and tests.

The `TChat` type provides a flat, vendor-agnostic structure for chat-like communication spaces, using `_rawRest` for provider-specific fields like `status` to maintain a cleaner core model.

---
<a href="https://cursor.com/background-agent?bcId=bc-202e0ffa-e0a9-498c-83c6-e2a894b55d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-202e0ffa-e0a9-498c-83c6-e2a894b55d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

