### PR TITLE
Api shortcuts and unified input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,61 @@
 <p align="center">
   <img alt="Agnet logo" src="media/agnet-logo.png" />
 </p>
+
+## Human-style vs Computer-style API
+
+Agnet has two parallel entrypoints built on the same execution model:
+
+- **Human-style**: `agnet.ask(request)` → `Promise<string>`
+  - Optimized for scripts, REPL usage, CLI, and docs examples
+  - **Syntax sugar for**: `await (await agnet.chats.create(request)).response()`
+
+- **Computer-style**: `agnet.prompt(request)` → `Promise<Result>`
+  - Optimized for programmatic workflows and integrations
+  - **Syntax sugar for**: `await (await agnet.chats.create(request)).result()`
+
+## Unified request input
+
+All of these accept the same input type:
+
+- `agnet.ask(request)`
+- `agnet.prompt(request)`
+- `agnet.chats.create(request)`
+
+```ts
+export type TAgentRequest =
+  | string
+  | {
+      providerId?: string;
+      prompt: string;
+    };
+```
+
+### Default provider resolution (deterministic)
+
+If `providerId` is not provided, Agnet resolves the default provider in this order:
+
+1. A provider explicitly marked as default (supported via `agent.extensions.default: true` or `agent.extensions.isDefault: true`)
+2. Otherwise, the **last registered** provider
+
+## Examples
+
+### API (TypeScript)
+
+```ts
+import { Agnet } from "agnet";
+
+const agnet = new Agnet();
+
+const response = await agnet.ask("hello");
+
+const result = await agnet.prompt("hello");
+console.log(result.text, result.providerId);
+```
+
+### CLI
+
+```bash
+agnet ask "hello"
+agnet prompt "hello" --provider mock-agent
+```

--- a/docs/generated/api.json
+++ b/docs/generated/api.json
@@ -4,6 +4,25 @@
   "profile": "default",
   "endpoints": [
     {
+      "id": "ask",
+      "pattern": "unary",
+      "args": [
+        {
+          "name": "prompt",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "providerId",
+          "type": "string",
+          "required": false,
+          "cli": {
+            "flag": "--provider"
+          }
+        }
+      ]
+    },
+    {
       "id": "chats.close",
       "pattern": "unary",
       "args": [
@@ -49,6 +68,25 @@
           "required": true,
           "cli": {
             "flag": "--prompt"
+          }
+        }
+      ]
+    },
+    {
+      "id": "prompt",
+      "pattern": "unary",
+      "args": [
+        {
+          "name": "prompt",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "providerId",
+          "type": "string",
+          "required": false,
+          "cli": {
+            "flag": "--provider"
           }
         }
       ]

--- a/docs/generated/api.md
+++ b/docs/generated/api.md
@@ -4,6 +4,16 @@ Version: **1**
 
 ---
 
+## ask.*
+
+### `ask` (unary)
+
+**Args**
+- `prompt` (string, required)
+- `providerId` (string, optional)
+
+---
+
 ## chats.*
 
 ### `chats.close` (unary)
@@ -25,6 +35,16 @@ Version: **1**
 **Args**
 - `chatId` (string, required)
 - `prompt` (string, required)
+
+---
+
+## prompt.*
+
+### `prompt` (unary)
+
+**Args**
+- `prompt` (string, required)
+- `providerId` (string, optional)
 
 ---
 

--- a/e2e/cli-agents.spec.ts
+++ b/e2e/cli-agents.spec.ts
@@ -54,6 +54,22 @@ test("chats create/send streams and prints final output", async () => {
   expect(res.stdout).toBe("MockAgent response #1: hello\n");
 });
 
+test("ask (root command) runs one-shot and prints final output", async () => {
+  const res = await runCli(["ask", "hello"]);
+  expect(res.code).toBe(0);
+  expect(res.stdout).toBe("MockAgent response #1: hello\n");
+});
+
+test("prompt (root command) runs one-shot and prints JSON result", async () => {
+  const res = await runCli(["prompt", "hello"]);
+  expect(res.code).toBe(0);
+
+  const parsed = JSON.parse(res.stdout) as { text: string; providerId: string; chatId: string };
+  expect(parsed.text).toBe("MockAgent response #1: hello");
+  expect(parsed.providerId).toBe("mock-agent");
+  expect(parsed.chatId).toMatch(/^chat-\d+-[a-f0-9]+$/);
+});
+
 test("chats create/send/close replays history across commands", async () => {
   const opened = await runCli(["chats", "create"]);
   expect(opened.code).toBe(0);

--- a/src/api/api-host.ts
+++ b/src/api/api-host.ts
@@ -25,6 +25,7 @@ async function loadProfileModules(profile: string): Promise<void> {
   void profile;
   await import("../apis/providers-api.js");
   await import("../apis/chats-api.js");
+  await import("../apis/shortcuts-api.js");
 }
 
 function isInternalEndpointId(id: string): boolean {

--- a/src/apis/chats-api.ts
+++ b/src/apis/chats-api.ts
@@ -34,7 +34,7 @@ export class ChatsApi {
     @Api.arg({ name: "providerId", type: "string", cli: { flag: "--provider" } })
     providerId?: string
   ): Promise<string> {
-    const resolvedProviderId = providerId ?? "mock-agent";
+    const resolvedProviderId = await this.providers.resolveDefaultProviderId(providerId);
     const chatId = randomId("chat");
     await writeChat(this.ctx.cwd, chatId, { version: 1, chatId, providerId: resolvedProviderId, history: [] });
     return chatId;

--- a/src/apis/shortcuts-api.ts
+++ b/src/apis/shortcuts-api.ts
@@ -1,0 +1,84 @@
+import { Api } from "../api/api.js";
+import type { ChatMessage } from "../protocol.js";
+import { readChat } from "../storage/chats.js";
+import { ChatsApi, type ChatsApiContext } from "./chats-api.js";
+
+function requireNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${label}: expected non-empty string`);
+  }
+  return value;
+}
+
+function stripTrailingNewlineOnce(text: string): string {
+  return text.endsWith("\n") ? text.slice(0, -1) : text;
+}
+
+/**
+ * CLI-facing sugar APIs.
+ *
+ * Philosophy:
+ * - `ask`: human-style, returns text
+ * - `prompt`: computer-style, returns structured JSON
+ */
+export class ShortcutsApi {
+  private readonly chats: ChatsApi;
+
+  constructor(private readonly ctx: ChatsApiContext) {
+    this.chats = new ChatsApi(ctx);
+  }
+
+  @Api.endpoint("ask")
+  async ask(
+    @Api.arg({ name: "prompt", type: "string", required: true, cli: { positionalIndex: 0 } })
+    prompt: string,
+    @Api.arg({ name: "providerId", type: "string", cli: { flag: "--provider" } })
+    providerId?: string
+  ): Promise<string> {
+    const content = requireNonEmptyString(prompt, "prompt");
+    const chatId = await this.chats.create(providerId);
+
+    try {
+      let out = "";
+      for await (const delta of this.chats.send(chatId, content)) out += typeof delta === "string" ? delta : "";
+      return out;
+    } finally {
+      // One-shot by default: don't clutter disk with short-lived chats.
+      try {
+        await this.chats.close(chatId);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
+  @Api.endpoint("prompt")
+  async prompt(
+    @Api.arg({ name: "prompt", type: "string", required: true, cli: { positionalIndex: 0 } })
+    prompt: string,
+    @Api.arg({ name: "providerId", type: "string", cli: { flag: "--provider" } })
+    providerId?: string
+  ): Promise<{ text: string; chatId: string; providerId: string; history: ChatMessage[] }> {
+    const content = requireNonEmptyString(prompt, "prompt");
+    const chatId = await this.chats.create(providerId);
+
+    try {
+      let out = "";
+      for await (const delta of this.chats.send(chatId, content)) out += typeof delta === "string" ? delta : "";
+      const persisted = await readChat(this.ctx.cwd, chatId);
+      return {
+        text: stripTrailingNewlineOnce(out),
+        chatId,
+        providerId: persisted.providerId,
+        history: Array.isArray(persisted.history) ? (persisted.history as ChatMessage[]) : []
+      };
+    } finally {
+      try {
+        await this.chats.close(chatId);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  }
+}
+

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -7,6 +7,7 @@ import type { ApiArgMeta, ApiEndpointMeta } from "../api/registry.js";
 import { getRegisteredEndpoints, resolveHandlerInstance } from "../api/registry.js";
 import { ChatsApi } from "../apis/chats-api.js";
 import { ProvidersApi } from "../apis/providers-api.js";
+import { ShortcutsApi } from "../apis/shortcuts-api.js";
 
 function toErrorMessage(err: unknown): string {
   if (!err) return "Unknown error";
@@ -272,6 +273,7 @@ export async function runCli(argv: string[]): Promise<void> {
   const ctx = { cwd: process.cwd(), env: process.env, mockAgentPath };
   Api.registerHandlerFactory(ProvidersApi, () => new ProvidersApi(ctx));
   Api.registerHandlerFactory(ChatsApi, () => new ChatsApi(ctx));
+  Api.registerHandlerFactory(ShortcutsApi, () => new ShortcutsApi(ctx));
 
   const endpoints = getRegisteredEndpoints();
   const publicEndpoints = endpoints.filter((e) => !e.internal);

--- a/tests/chats.test.ts
+++ b/tests/chats.test.ts
@@ -16,7 +16,7 @@ describe("Agnet.chats", () => {
       runtime: { transport: "cli", command: process.execPath, args: [mockAgentPath] }
     });
 
-    const chat = await an.chats.create({ providerId: "mock-agent" });
+    const chat = await an.chats.open({ providerId: "mock-agent" });
     const out = await chat.send("hello");
     expect(out).toBe("MockAgent response #1: hello\n");
 

--- a/tests/examples/examples.test.ts
+++ b/tests/examples/examples.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+
+import { Agnet } from "../../src/agnet.js";
+
+/**
+ * Examples-as-tests safety net.
+ *
+ * Keep these snippets aligned with README examples.
+ */
+describe("README examples", () => {
+  it("ask (human-style) and prompt (computer-style) work against the mock provider", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-examples-"));
+    const mockAgentPath = path.join(process.cwd(), "bin", "mock-agent.mjs");
+
+    const agnet = new Agnet({ cwd });
+    agnet.providers.register({
+      agent: { id: "mock-agent", name: "Mock Agent", version: "0.0.0", skills: [{ id: "chat" }] },
+      runtime: { transport: "cli", command: process.execPath, args: [mockAgentPath] }
+    });
+
+    const response = await agnet.ask("hello");
+    expect(response).toBe("MockAgent response #1: hello");
+
+    const result = await agnet.prompt("hello");
+    expect(result.text).toBe("MockAgent response #1: hello");
+    expect(result.providerId).toBe("mock-agent");
+  });
+});
+

--- a/tests/register-mdx.test.ts
+++ b/tests/register-mdx.test.ts
@@ -37,7 +37,7 @@ Talk.
       "utf-8"
     );
 
-    const ai = new Agnet();
+    const ai = new Agnet({ cwd: dir });
     const ref = ai.providers.register(mdxPath);
     expect(ref.id).toBe("mdx-a");
     expect(ref.runtime?.transport).toBe("http");

--- a/tests/register.test.ts
+++ b/tests/register.test.ts
@@ -6,8 +6,9 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { Agnet, resolveAuthHeaders } from "../src/agnet.js";
 
 describe("Agnet.providers.register", () => {
-  it("registers from a parsed config object", () => {
-    const ai = new Agnet();
+  it("registers from a parsed config object", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-register-"));
+    const ai = new Agnet({ cwd });
     const ref = ai.providers.register({
       agent: {
         id: "a1",
@@ -21,8 +22,9 @@ describe("Agnet.providers.register", () => {
     expect(ai.providers.get("a1")?.card.name).toBe("Agent One");
   });
 
-  it("registers from { card, adapter }", () => {
-    const ai = new Agnet();
+  it("registers from { card, adapter }", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-register-"));
+    const ai = new Agnet({ cwd });
     const ref = ai.providers.register({
       card: { id: "adapter-agent", name: "Adapter Agent", version: "1.0.0", skills: [{ id: "chat" }] },
       adapter: { kind: "unit-test" }
@@ -43,14 +45,15 @@ describe("Agnet.providers.register", () => {
       "utf-8"
     );
 
-    const ai = new Agnet();
+    const ai = new Agnet({ cwd: dir });
     const ref = ai.providers.register(jsonPath);
     expect(ref.id).toBe("from-file");
     expect(ref.runtime?.transport).toBe("http");
   });
 
-  it("throws a clear field-path error on invalid config", () => {
-    const ai = new Agnet();
+  it("throws a clear field-path error on invalid config", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-register-"));
+    const ai = new Agnet({ cwd });
     expect(() =>
       ai.providers.register({
         agent: { name: "x", version: "1.0.0", skills: [{ id: "chat" }] },

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+
+import { Agnet } from "../src/agnet.js";
+
+function mockProviderConfig(params: { id: string; mockAgentPath: string; isDefault?: boolean }) {
+  return {
+    agent: {
+      id: params.id,
+      name: `Mock ${params.id}`,
+      version: "0.0.0",
+      skills: [{ id: "chat" }],
+      ...(params.isDefault ? { extensions: { default: true } } : {})
+    },
+    runtime: { transport: "cli" as const, command: process.execPath, args: [params.mockAgentPath] }
+  };
+}
+
+describe("Agnet API shortcuts (ask/prompt) + unified request input", () => {
+  it("ask(request) is syntax sugar for chats.create(request).response()", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-shortcuts-"));
+    const mockAgentPath = path.join(process.cwd(), "bin", "mock-agent.mjs");
+
+    const an = new Agnet({ cwd });
+    an.providers.register(mockProviderConfig({ id: "mock-agent", mockAgentPath }));
+
+    const a = await an.ask("hello");
+    const b = await (await an.chats.create("hello")).response();
+    expect(a).toBe(b);
+    expect(a).toBe("MockAgent response #1: hello");
+  });
+
+  it("prompt(request) is syntax sugar for chats.create(request).result()", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-shortcuts-"));
+    const mockAgentPath = path.join(process.cwd(), "bin", "mock-agent.mjs");
+
+    const an = new Agnet({ cwd });
+    an.providers.register(mockProviderConfig({ id: "mock-agent", mockAgentPath }));
+
+    const a = await an.prompt("hello");
+    const b = await (await an.chats.create("hello")).result();
+    expect(a.text).toBe(b.text);
+    expect(a.providerId).toBe("mock-agent");
+    expect(a.text).toBe("MockAgent response #1: hello");
+  });
+
+  it("supports object input (providerId optional) and string shorthand everywhere", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-shortcuts-"));
+    const mockAgentPath = path.join(process.cwd(), "bin", "mock-agent.mjs");
+
+    const an = new Agnet({ cwd });
+    an.providers.register(mockProviderConfig({ id: "mock-agent", mockAgentPath }));
+
+    const a = await an.prompt({ prompt: "hello" });
+    const b = await an.prompt("hello");
+    expect(a.text).toBe("MockAgent response #1: hello");
+    expect(b.text).toBe("MockAgent response #1: hello");
+  });
+
+  it("default provider resolution is deterministic: last registered unless a default is marked", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agnet-shortcuts-"));
+    const mockAgentPath = path.join(process.cwd(), "bin", "mock-agent.mjs");
+
+    // Case A: no default -> last registered wins.
+    const an1 = new Agnet({ cwd });
+    an1.providers.register(mockProviderConfig({ id: "p1", mockAgentPath }));
+    an1.providers.register(mockProviderConfig({ id: "p2", mockAgentPath }));
+    expect((await an1.prompt("hello")).providerId).toBe("p2");
+
+    // Case B: default marked -> default wins even if registered earlier.
+    const cwd2 = await mkdtemp(path.join(os.tmpdir(), "agnet-shortcuts-"));
+    const an2 = new Agnet({ cwd: cwd2 });
+    an2.providers.register(mockProviderConfig({ id: "p-default", mockAgentPath, isDefault: true }));
+    an2.providers.register(mockProviderConfig({ id: "p-latest", mockAgentPath }));
+    expect((await an2.prompt("hello")).providerId).toBe("p-default");
+  });
+});
+


### PR DESCRIPTION
Add `agnet.ask()` and `agnet.prompt()` root APIs with unified request input and deterministic default provider resolution to simplify one-shot requests and ensure consistent behavior across API and CLI.

---
<a href="https://cursor.com/background-agent?bcId=bc-33ef2d75-249b-42e3-8150-b754699a7782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33ef2d75-249b-42e3-8150-b754699a7782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

